### PR TITLE
ruff override

### DIFF
--- a/app/general/admin.py
+++ b/app/general/admin.py
@@ -14,7 +14,7 @@ class ProjectAdminInline(admin.TabularInline):
 class DocumentFileForm(ModelForm):
     class Meta:
         model = DocumentFile
-        fields = fields_for_model(DocumentFile)
+        fields = "__all__"  # noqa: DJ007
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
I get the linter's point. In a mature project __all__ is maybe not a good idea. I think it is a bit too pedantic in this case (as "__all__ " is documented by the project as the right way to do it), and the function call `fields_for_model()` is equivalent. So the linter just isn't clever enough to complain about the function call as it suffers from exactly the same weak points. See https://docs.astral.sh/ruff/rules/django-all-with-model-form/