### PR TITLE
Add dark mode css file, and add to admin template

### DIFF
--- a/app/static/css/admin.css
+++ b/app/static/css/admin.css
@@ -8,7 +8,10 @@
 html[data-theme="light"],
 :root {
     --primary: #1a2f69;
+    --secondary: #b0b4d9;
     --primary-light: #8288bc;
+    --primary-black: #000000;
+    --primary-white: #fff;
 
     --header-color: var(--primary-light);
     --header-branding-color: var(--primary-light);
@@ -47,9 +50,11 @@ a.section:link, a.section:visited {
     color: var(--link-fg);
 }
 
-.theme-toggle svg.theme-icon-when-auto, .theme-toggle svg.theme-icon-when-dark, .theme-toggle svg.theme-icon-when-light {
-    fill: var(--link-fg);
-    color: #fff;
+.theme-toggle svg.theme-icon-when-auto,
+.theme-toggle svg.theme-icon-when-dark,
+.theme-toggle svg.theme-icon-when-light {
+    fill: var(--primary-black);
+    color: var(--primary-white);
 }
 
 .header-title {
@@ -60,4 +65,9 @@ a.section:link, a.section:visited {
     margin-left: 1px;
     width: auto;
     height: 70px;
+}
+
+
+.module h2, .module caption, .inline-group h2 {
+    color: var(--primary-white);
 }

--- a/app/static/css/dark_mode_override.css
+++ b/app/static/css/dark_mode_override.css
@@ -1,0 +1,37 @@
+/*
+    Django admin styles
+    extended from https://github.com/django/django/blob/main/django/contrib/admin/static/admin/css/dark_mode.css
+    Remember to sync colours with front-end CSS.
+*/
+
+@media (prefers-color-scheme: dark) {
+    :root {
+      --primary: #1a2f69;
+      --secondary: #485d95;
+      --primary-black: #000000;
+      --primary-white: #fff;
+
+      --link-hover-color: var(--primary-white);
+
+      --link-fg: #81d4fa;
+
+      --selected-row: #2d4481;
+    }
+  }
+
+
+html[data-theme="dark"] {
+    --primary: #1a2f69;
+    --secondary: #485d95;
+    --primary-black: #000000;
+    --primary-white: #fff;
+
+    --link-fg: #81d4fa;
+    --link-hover-color: var(--primary-white);
+
+    --selected-row: #2d4481;
+}
+
+#header a:link, #header a:visited, #logout-form button {
+    color: var(--primary-black);
+}

--- a/app/templates/admin/base_site.html
+++ b/app/templates/admin/base_site.html
@@ -12,6 +12,7 @@
 
 {% block extrastyle %}
   <link rel="stylesheet" href="{% static 'css/admin.css' %}">
+  <link rel="stylesheet" href="{% static 'css/dark_mode_override.css' %}">
 {% endblock %}
 
 {% block branding %}
@@ -24,4 +25,3 @@
   {% include "admin/color_theme_toggle.html" %}
 {% endif %}
 {% endblock %}
-


### PR DESCRIPTION
In this PR, we add a dark mode css file that extends from the django dark mode one, with styling according to SADiLaR colours 