### PR TITLE
Bug: handle pypdf errors

### DIFF
--- a/app/general/service/extract_text.py
+++ b/app/general/service/extract_text.py
@@ -25,3 +25,5 @@ class GetTextFromPDF:
 
             except PdfStreamError:
                 raise GetTextError("The uploaded PDF file is corrupted or not fully downloaded.")
+            except Exception:
+                raise GetTextError("Error during text extraction from PDF file.")


### PR DESCRIPTION
Any error in pypdf crashes the bulk import command instead of just skipping the problematic file. E.g.

```
Traceback (most recent call last):

  ...

  File "/app/general/service/extract_text.py", line 18, in to_text
    reader = PdfReader(self.uploaded_file)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pypdf/_reader.py", line 127, in __init__
    self.read(stream)
  File "/usr/local/lib/python3.12/site-packages/pypdf/_reader.py", line 543, in read
    xref_issue_nr = self._get_xref_issues(stream, startxref)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pypdf/_reader.py", line 945, in _get_xref_issues
    stream.seek(startxref - 1, 0)  # -1 to check character before
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: negative seek value -1
```