### PR TITLE
Ensure HTML pages vary on HX-Request

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -77,6 +77,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
     "django_htmx.middleware.HtmxMiddleware",
+    "general.middleware.ExtraVaryMiddleware",
 ]
 
 if DEBUG and DEBUG_TOOLBAR:

--- a/app/general/middleware.py
+++ b/app/general/middleware.py
@@ -1,0 +1,17 @@
+from django.utils.cache import patch_vary_headers
+
+
+class ExtraVaryMiddleware:
+    """Ensure HTML pages vary on HX-Request
+
+    This is needed so that incomplete responses based on base_htmx.html are not
+    reused as full-page responses, for example on browser restore of a page."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if "text/html" in response.headers["Content-Type"]:
+            patch_vary_headers(response, ["HX-Request"])
+        return response


### PR DESCRIPTION
This fixes the problem with a partial page showing on browser restore, or for example with Firefox plugin "Auto Tab Discard" if a tab is restored. It will also be required if "real" caching is implemented.