### PR TITLE
fix(a11y): put 'ongoing' after 'end date'

### DIFF
--- a/app/templates/app/project_detail.html
+++ b/app/templates/app/project_detail.html
@@ -35,12 +35,24 @@
         <div class="row">
           <p class="col-lg-6">
               {% icon "date" %}
-              {% trans "Start Date:" %} {{ project.start_date|date:"Y-m-d" }}
+              {% trans "Start Date:" %}
+
+              {% if project.start_date %}
+              {{ project.start_date|date:"Y-m-d" }}
+              {% else %}
+              <span class="text-muted">{% trans "unspecified" %}</span>
+              {% endif %}
           </p>
 
           <p class="col-lg-6">
               {% icon "date" %}
-              {% trans "End Date:" %} {{ project.end_date|date:"Y-m-d" }}
+              {% trans "End Date:" %}
+              
+              {% if project.end_date %}
+              {{ project.end_date|date:"Y-m-d"|default:"" }}
+              {% else %}
+              <span class="text-muted">{% trans "ongoing" %}</span>
+              {% endif %}
           </p>
         </div>
 


### PR DESCRIPTION
Before this change, the screen-reader would simply read "End Date:" and trail off. Now, it will read "End Date: Ongoing". For sighted users, the text is slightly greyed-out to indicate that the end date is not _really_ there (as the project is ongoing).

![image](https://github.com/user-attachments/assets/f2c92317-c164-42c3-80d5-8092ec75896c)
