### PR TITLE
chore(ci): don't run push & PR on PR branches

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,13 @@
 name: Testing Django
-on: [ pull_request, push ] # activates the workflow when there is a push or pull request in the repo
+
+# Activates the workflow when there is a push or pull request in the repo
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+
 jobs:
   test_project:
     runs-on: ubuntu-latest # operating system your code will run on


### PR DESCRIPTION
This change prevents duplicate runs from occurring when opening a pull request on GitHub. Before, both the 'push' and 'pull_request' hooks would trigger, meaning that any push to a branch with an open PR would run the CI pipeline twice. By filtering the 'push' hook to 'main' and 'develop', we avoid this.

The tangible benefit of this is
 1. we avoid oversubmitting GitHub CI jobs, so if we have more jobs to run in the future (see #132, which will add a new, separate lighthouse job), we get all the results quicker
 2. fixes the annoyance of having two failures/successes when it should only really be one