### PR TITLE
fix(build): copy entrypoint before app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN <<EOF
 EOF
 
 # Copy project
-COPY ./app /app/
 COPY ./entrypoint.sh /
+COPY ./app /app/
 
 # Run the application
 ENTRYPOINT ["bash", "/entrypoint.sh"]


### PR DESCRIPTION
This is better as app/ will likely change more often than entrypoint.sh. Thus, this change increases the degree to which the container's build layers can be cached