### PR TITLE
chore(ci): lint for bang commits (fixup, squash, drop, edit)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -117,3 +117,28 @@ jobs:
         with:
           name: django-logs
           path: app/debug.log
+  lint-commits:
+    runs-on: ubuntu-latest
+    if: github.event.ref != 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get all commits on current main
+        run: git fetch origin main
+      - name: Log all commits we will analyse
+        run: git log --pretty=format:%s origin/main..HEAD
+
+      # - We use -v here, which inverts the match, because we want to output an exit status of 1 when a match _is_
+      #   found (usually 0 is for a match)
+      # - We use a -z here, which makes \0 be the line separator, because if feeding multiline text into grep, it will
+      #   exit with a status of 0 regardless of whether there is a match (so, -z makes it treat the input as one line)
+      - name: Disallow fixup commits
+        run: git log --pretty=format:%s origin/main..HEAD | grep -zv 'fixup!'
+      - name: Disallow squash commits
+        run: git log --pretty=format:%s origin/main..HEAD | grep -zv 'squash!'
+      - name: Disallow edit commits
+        run: git log --pretty=format:%s origin/main..HEAD | grep -zv 'edit!'
+      - name: Disallow drop commits
+        run: git log --pretty=format:%s origin/main..HEAD | grep -zv 'drop!'


### PR DESCRIPTION
This makes sure we don't accidentally merge commits which should be squashed up or rebased first.