### PR TITLE
test: run Selenium tests on more browsers/JS configurations

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -69,7 +69,13 @@ jobs:
           cd app/
           python manage.py check
   selenium:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        browser-and-os:
+          - [firefox, ubuntu-latest]
+          - [chrome, ubuntu-latest]
+        js: [js-enabled, js-disabled]
+    runs-on: ${{ matrix.browser-and-os[1] }}
     services:
       postgres:
         image: postgres:16
@@ -101,7 +107,7 @@ jobs:
           cp .env.testing app/.env
           cd app/
           mkdir -p static_files
-          python manage.py test --tag=selenium
+          BROWSER=${{ matrix.browser-and-os[0] }} ENABLE_JS=${{ matrix.js }} python manage.py test --tag=selenium
         env:
           DJANGO_SETTINGS_MODULE: app.settings
           DATABASE_URL: postgres://sadilar:sadilar@localhost:5432/test_db

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -60,7 +60,7 @@ jobs:
           cp .env.testing app/.env
           cd app/
           mkdir -p static_files
-          python manage.py test
+          python manage.py test --exclude-tag=selenium
         env:
           DJANGO_SETTINGS_MODULE: app.settings
           DATABASE_URL: postgres://sadilar:sadilar@localhost:5432/test_db
@@ -68,6 +68,43 @@ jobs:
         run: |
           cd app/
           python manage.py check
+  selenium:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: sadilar
+          POSTGRES_PASSWORD: sadilar
+          POSTGRES_DB: test_db_1
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+          sudo apt-get install -y gettext
+      - name: Create logging folder
+        run: |
+          sudo  mkdir -p /logging
+          sudo chown runner:runner /logging
+      - name: Run Selenium Tests
+        run: |
+          cp .env.testing app/.env
+          cd app/
+          mkdir -p static_files
+          python manage.py test --tag=selenium
+        env:
+          DJANGO_SETTINGS_MODULE: app.settings
+          DATABASE_URL: postgres://sadilar:sadilar@localhost:5432/test_db
   lighthouse:
     runs-on: ubuntu-latest # operating system your code will run on
     services:

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ create-schema:
 	@docker compose run --rm web python manage.py graph_models -a -o schema/schema.png
 
 test:
-	@docker compose run --rm web python manage.py test $(module)
+	@docker compose run --rm -e BROWSER -e JS_ENABLED  web python manage.py test $(module)
 
 ruff-check:
 	@docker compose run --rm web ruff check .

--- a/app/general/tests/files/test_js.html
+++ b/app/general/tests/files/test_js.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<body>
+    <script>
+        document.querySelector("body").innerHTML = "<p id='js-enabled'>Hello world!</p>";
+    </script>
+</body>
+</html>

--- a/app/general/tests/test_frontend.py
+++ b/app/general/tests/test_frontend.py
@@ -1,4 +1,5 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.test import tag
 from selenium.common import TimeoutException
 from selenium.webdriver.chrome.webdriver import Options, WebDriver
 from selenium.webdriver.common.by import By
@@ -8,6 +9,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 WAIT_TIMEOUT = 5
 
 
+@tag("selenium")
 class TestFrontend(StaticLiveServerTestCase):
     @classmethod
     def setUpClass(cls):

--- a/app/general/tests/test_frontend.py
+++ b/app/general/tests/test_frontend.py
@@ -1,8 +1,21 @@
+import os
+
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test import tag
 from selenium.common import TimeoutException
-from selenium.webdriver.chrome.webdriver import Options, WebDriver
+from selenium.webdriver.chrome.webdriver import (
+    Options as ChromeOptions,
+)
+from selenium.webdriver.chrome.webdriver import (
+    WebDriver as ChromeWebDriver,
+)
 from selenium.webdriver.common.by import By
+from selenium.webdriver.firefox.webdriver import (
+    Options as FirefoxOptions,
+)
+from selenium.webdriver.firefox.webdriver import (
+    WebDriver as FirefoxWebDriver,
+)
 from selenium.webdriver.support.wait import WebDriverWait
 
 # Wait timeout in seconds
@@ -13,19 +26,53 @@ WAIT_TIMEOUT = 5
 class TestFrontend(StaticLiveServerTestCase):
     @classmethod
     def setUpClass(cls):
-        opts = Options()
-        opts.add_argument("--headless")
-        opts.add_argument("--no-sandbox")
-        opts.add_argument("--disable-dev-shm-usage")
-        opts.add_argument("--window-size=1920,1080")
-        cls.driver = WebDriver(opts)
+        browser = os.environ.get("BROWSER", "chrome").lower()
+        cls.js_enabled = os.environ.get("JS_ENABLED", "js-enabled") == "js-enabled"
+
+        print(
+            f"Running Selenium tests on {browser}. JS is {'enabled' if cls.js_enabled else 'disabled'}."
+        )
+
+        if browser == "chrome":
+            opts = ChromeOptions()
+            opts.add_argument("--headless=new")
+            opts.add_argument("--no-sandbox")
+            opts.add_argument("--disable-dev-shm-usage")
+            opts.add_argument("--window-size=1920,1080")
+
+            if not cls.js_enabled:
+                # Taken from https://stackoverflow.com/a/73961818
+                prefs = dict()
+                prefs["webkit.webprefs.javascript_enabled"] = False
+                prefs["profile.content_settings.exceptions.javascript.*.setting"] = 2
+                prefs["profile.default_content_setting_values.javascript"] = 2
+                prefs["profile.managed_default_content_settings.javascript"] = 2
+                opts.add_experimental_option("prefs", prefs)
+                opts.add_argument("--disable-javascript")
+
+            cls.driver = ChromeWebDriver(opts)
+        elif browser == "firefox":
+            options = FirefoxOptions()
+            options.add_argument("-headless")
+            options.set_preference("javascript.enabled", cls.js_enabled)
+            cls.driver = FirefoxWebDriver(options=options)
+
         cls.driver.implicitly_wait(WAIT_TIMEOUT)
+
         super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):
         cls.driver.quit()
         super().tearDownClass()
+
+    # Checks that JS is properly disabled if passed through env var, else check if enabled
+    def test_js_enabled_or_disabled(self):
+        test_dir = os.getenv("TESTING_DIR", "/app/general/tests/files")
+        self.driver.get(f"file://{test_dir}/test_js.html")
+        self.assertEqual(
+            len(self.driver.find_elements(By.ID, "js-enabled")), 1 if self.js_enabled else 0
+        )
 
     def test_no_404s(self):
         # Sanity check in case we ever change the 404 title


### PR DESCRIPTION
By passing the browser type and whether JS is enabled via environment variables, we can run the Selenium front-end tests on all combinations of targeted browsers and JS/no-JS in the CI pipeline. The way it works from the CI perspective is by using a Matrix strategy which is then substituted into an environment variable when calling `manage.py test --tag=selenium`

Fixes #143. However, #145 is not addressed, as this PR doesn't tackle Safari. This is because GitHub Actions MacOS workers don't support  `services`, which  we use to run the postgres database. This can be left for a follow-up PR.