### PR TITLE
tweak: only show subjects which have documents or projects associated

### DIFF
--- a/app/app/views.py
+++ b/app/app/views.py
@@ -97,7 +97,7 @@ def projects(request):
     if institution_id := request.GET.get("institution"):
         projects = projects.filter(institution__id=institution_id)
 
-    subjects = Subject.objects.order_by("name")
+    subjects = Subject.objects.get_used_subjects().order_by("name")
     languages = Language.objects.order_by("name")
     institutions = Institution.objects.order_by("name")
 
@@ -191,7 +191,7 @@ def documents(request):
     page_number = request.GET.get("page")
     page_obj = paginator.get_page(page_number)
 
-    subjects = Subject.objects.order_by("name")
+    subjects = Subject.objects.get_used_subjects().order_by("name")
     languages = Language.objects.order_by("name")
     institutions = Institution.objects.order_by("name")
 

--- a/app/general/models.py
+++ b/app/general/models.py
@@ -2,6 +2,7 @@ from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVector, SearchVectorField
 from django.core.validators import FileExtensionValidator
 from django.db import models
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from simple_history.models import HistoricalRecords
 
@@ -68,11 +69,18 @@ class Language(models.Model):
         return self.name
 
 
+class SubjectManager(models.Manager):
+    def get_used_subjects(self):
+        """Returns only the subjects that have documents or projects associated with them"""
+        return self.filter(Q(document__isnull=False) | Q(project__isnull=False)).distinct()
+
+
 class Subject(models.Model):
     name = models.CharField(max_length=150, unique=True, verbose_name=_("name"))
 
     # added simple historical records to the model
     history = HistoricalRecords()
+    objects = SubjectManager()
 
     class Meta:
         verbose_name = _("Subject")

--- a/app/general/tests/test_documents.py
+++ b/app/general/tests/test_documents.py
@@ -7,7 +7,7 @@ from general.models import Document, Institution, Language, Subject
 class DocumentViewTests(TestCase):
     def setUp(self):
         self.subject1 = Subject.objects.create(name="Subject 1")
-        self.subject2 = Subject.objects.create(name="Subject 2")
+        self.unused_subject = Subject.objects.create(name="Unused subject")
         self.language1 = Language.objects.create(name="Language 1", iso_code="lang1")
         self.language2 = Language.objects.create(name="Language 2", iso_code="lang2")
         self.language3 = Language.objects.create(name="Language 3", iso_code="lang3")
@@ -39,6 +39,8 @@ class DocumentViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="main-heading"')
+        self.assertContains(response, self.subject1.name)
+        self.assertNotContains(response, self.unused_subject.name)
         self.assertIn("documents", response.context)
 
     def test_with_filters(self):

--- a/app/general/tests/tests_projects.py
+++ b/app/general/tests/tests_projects.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import datetime
 
 from django.test import TestCase
+from django.urls import reverse
 
 from general.models import Institution, Language, Project, Subject
 
@@ -10,6 +11,7 @@ class TestProjects(TestCase):
     def setUp(self):
         self.institution = Institution.objects.create(name="Test Institution")
         self.subject = Subject.objects.create(name="Test Subject")
+        self.unused_subject = Subject.objects.create(name="Unused subject")
         self.language = Language.objects.create(name="Test Language", iso_code="TL")
         self.project = Project.objects.create(
             name="Test Project",
@@ -69,6 +71,16 @@ class TestProjects(TestCase):
         self.assertEqual(self.project.history.first().start_date.strftime("%Y-%m-%d"), "2023-01-01")
         self.assertEqual(self.project.history.first().end_date.strftime("%Y-%m-%d"), "2023-12-31")
         self.assertEqual(self.project.history.first().institution, self.institution)
+
+    def test_view_basics(self):
+        with self.assertNumQueries(6):
+            response = self.client.get(reverse("projects"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="main-heading"')
+        self.assertContains(response, self.subject.name)
+        self.assertNotContains(response, self.unused_subject.name)
+        self.assertIn("projects", response.context)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The page is pretty snappy, so I don't think caching will be needed at this time (maybe if it's slow on the test deployment). It is the same number of queries overall (though one of them is a bit heavier, being a join compared to a simple select).

## Before
![image](https://github.com/user-attachments/assets/d53fe3d2-7c2f-4114-9d39-751189773ea0)

## After
![image](https://github.com/user-attachments/assets/31719ea8-f31b-4ee1-9f21-15c8ac2c005c)


