### PR TITLE
ci: simplify environment variables in CI scripts

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -100,9 +100,10 @@ jobs:
         run: |
           sudo  mkdir -p /logging
           sudo chown runner:runner /logging
+      - name: Install .env.testing
+        run: cp .env.testing app/.env
       - name: Run Selenium Tests
         run: |
-          cp .env.testing app/.env
           cd app/
           mkdir -p static_files
           BROWSER=${{ matrix.browser-and-os[0] }} ENABLE_JS=${{ matrix.js }} python manage.py test --tag=selenium
@@ -134,7 +135,7 @@ jobs:
           pip install -r requirements-test.txt
           sudo apt-get install -y gettext
           npm install -g @lhci/cli@0.14.x
-      - name: Setup LHCI env
+      - name: Install .env.lhci
         run: cp .env.lhci app/.env
       - name: Run Django fixtures
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -44,22 +44,21 @@ jobs:
         run: |
           sudo  mkdir -p /logging
           sudo chown runner:runner /logging
+      - name: Install .env.testing
+        run: cp .env.testing app/.env
       - name: Compile Translation Messages
         run: |
-          cp .env.testing app/.env
           cd app/
           python manage.py makemessages --all
           python manage.py compilemessages
       - name: Run validate_templates
         run: |
           export DJANGO_TEST_PROCESSES=1
-          cp .env.testing app/.env
           cd app/
           mkdir -p static_files
           python manage.py validate_templates --ignore-app django_filters
       - name: Run Tests
         run: |
-          cp .env.testing app/.env
           cd app/
           mkdir -p static_files
           python manage.py test --exclude-tag=selenium

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -62,9 +62,6 @@ jobs:
           cd app/
           mkdir -p static_files
           python manage.py test --exclude-tag=selenium
-        env:
-          DJANGO_SETTINGS_MODULE: app.settings
-          DATABASE_URL: postgres://sadilar:sadilar@localhost:5432/test_db
       - name: Manager Check
         run: |
           cd app/
@@ -109,9 +106,6 @@ jobs:
           cd app/
           mkdir -p static_files
           BROWSER=${{ matrix.browser-and-os[0] }} ENABLE_JS=${{ matrix.js }} python manage.py test --tag=selenium
-        env:
-          DJANGO_SETTINGS_MODULE: app.settings
-          DATABASE_URL: postgres://sadilar:sadilar@localhost:5432/test_db
   lighthouse:
     runs-on: ubuntu-latest # operating system your code will run on
     services:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   test_project:
-    runs-on: ubuntu-latest # operating system your code will run on
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:16
@@ -107,7 +107,7 @@ jobs:
           mkdir -p static_files
           BROWSER=${{ matrix.browser-and-os[0] }} ENABLE_JS=${{ matrix.js }} python manage.py test --tag=selenium
   lighthouse:
-    runs-on: ubuntu-latest # operating system your code will run on
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:16


### PR DESCRIPTION
We have a lot of useless variables and things that don't make sense