### PR TITLE
fix: align leftmost contact column text to title

### DIFF
--- a/app/templates/app/about.html
+++ b/app/templates/app/about.html
@@ -76,7 +76,7 @@
     <div class="card p-3 row">
         <h2 class="card-title">{% trans "Contact" %}</h2>
         <div class="row gx-lg-5">
-            <div class="col-md-auto contact-info">
+            <div class="col-md-auto contact-info ps-3">
                 <p>
                     {% trans "Dr Michelle Goosen" %}
                 </p>


### PR DESCRIPTION
Fixes #158 