### PR TITLE
Avoid long lists of documents

### DIFF
--- a/app/templates/app/_documents.html
+++ b/app/templates/app/_documents.html
@@ -1,0 +1,40 @@
+{% load bs_icons %}
+{% load i18n %}
+
+<h3 class="fs-4">{% trans "Documents" %}</h3>
+
+{% comment %}
+    Instead of showing a long list to the user, include a long list in a closed
+    `<details>` (styled as Bootstrap accordion) to make the page easier to
+    navigate.
+{% endcomment %}
+
+{% if item.documents|length > 10 %}
+<div class="accordion">
+    <details class="mb-2 accordion-item">
+        <summary class="accordion-button collapsed">
+            {% comment %}
+                The singular case won't happen, but proper plural handling is
+                needed to allow other languages to handle all cases correctly.
+            {% endcomment %}
+            {% blocktranslate trimmed count docs=item.documents|length %}
+                One document
+            {% plural %}
+                {{ docs }} documents
+            {% endblocktranslate %}
+        </summary>
+{% endif %}
+
+    <ul class="list-unstyled mt-2">
+        {% for document in item.documents %}
+        <li class="mb-2">
+            {% icon "document" %}
+            <a href="{% url 'document_detail' document.id %}">{{ document.title }}</a>
+        </li>
+        {% endfor %}
+    </ul>
+
+{% if item.documents|length > 10 %}
+    </details>
+</div>
+{% endif %}

--- a/app/templates/app/css/local.css
+++ b/app/templates/app/css/local.css
@@ -95,3 +95,11 @@ footer {
 .card-body:not(.row) > :last-child {
     margin-bottom: 0;
 }
+
+/*{# bootstrap uses .collapsed and JS instead of [open] #}*/
+details.accordion-item[open] .accordion-button::after {
+  transform:var(--bs-accordion-btn-icon-transform)
+}
+summary.accordion-button::-webkit-details-marker {
+  display:none
+}

--- a/app/templates/app/languages.html
+++ b/app/templates/app/languages.html
@@ -15,17 +15,7 @@
         <h2>{{ item.language.name }}</h2>
         <div class="col-md-6">
             {% if item.documents.exists %}
-            <h3 class="fs-4">{% trans "Documents" %}</h3>
-            <div class="documents">
-                <ul class="list-unstyled">
-                    {% for document in item.documents %}
-                    <li class="mb-2">
-                        {% icon "document" %}
-                        <a href="{% url 'document_detail' document.id %}">{{ document.title }}</a>
-                    </li>
-                    {% endfor %}
-                </ul>
-            </div>
+                {% include "app/_documents.html" %}
             {% else %}
                 {# Only show this in two-column mode to ensure consistent layout and placement #}
                 <div aria-hidden="true" class="d-none d-md-block">

--- a/app/templates/app/subjects.html
+++ b/app/templates/app/subjects.html
@@ -15,17 +15,7 @@
         <h2>{{ item.subject.name }}</h2>
         <div class="col-md-6">
             {% if item.documents.exists %}
-            <h3 class="fs-4">{% trans "Documents" %}</h3>
-            <div class="documents">
-                <ul class="list-unstyled">
-                    {% for document in item.documents %}
-                    <li class="mb-2">
-                        {% icon "document" %}
-                        <a href="{% url 'document_detail' document.id %}">{{ document.title }}</a>
-                    </li>
-                    {% endfor %}
-                </ul>
-            </div>
+                {% include "app/_documents.html" %}
             {% else %}
                 {# Only show this in two-column mode to ensure consistent layout and placement #}
                 <div aria-hidden="true" class="d-none d-md-block">


### PR DESCRIPTION
This hopefully makes rendering and browsing the languages and subjects pages a bit simpler, and refactors a reused bit. We can consider doing the same for projects.

The custom CSS is to work correctly without Bootstrap's JS on browsers that support the [open] selector (should be almost 100% supported now), and to fix a webkit/safari bug (visible with the GNOME browser).