### PR TITLE
Upgrade Django to 5.2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ django-environ==0.12.0
 django-filter==25.1
 django-htmx==1.23.2
 django-simple-history==3.10.1
-django==5.2.4
+django==5.2.9
 gunicorn==23.0.0
 pillow==11.3.0
 psycopg2-binary==2.9.10


### PR DESCRIPTION
This is to upgrade Django to version 5.2.9.

I ran the full test suite before and after the upgrade and observed no new errors or regressions.
The application also starts and runs correctly locally after the upgrade.

This is intended as a pretty straightforward dependency update.