### PR TITLE
Feature/validate urls command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: list up upd build stop down restart make-migrations migrate collectstatic shell logs create-super-user \
         docker-stop-all create-schema test ruff-check ruff-fix ruff-format load-fixtures pre-commit-install \
         dev-import-documents dev-quick-install lighthouse dev_update_vector_search docker-shell check make-messages \
-        compile-messages fmt lint fix
+        compile-messages fmt lint fix validate-urls
 
 list:
 	@echo "Available commands:"
@@ -30,6 +30,7 @@ list:
 	@echo "compile-messages - Run command to ensure translation .mo files are created"
 	@echo "docker-shell - Access the container shell"
 	@echo "check - Run the Django check command"
+	@echo "validate-urls - Validate stored URLs for Projects, Documents and Institutions"
 
 up:
 	@docker compose up
@@ -127,3 +128,6 @@ make-messages:
 
 compile-messages:
 	@docker compose run --rm web python manage.py compilemessages
+
+validate-urls:
+	@docker compose run --rm web python manage.py validate_urls

--- a/app/general/management/commands/validate_urls.py
+++ b/app/general/management/commands/validate_urls.py
@@ -1,0 +1,105 @@
+import ssl
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.urls import reverse
+
+from general.models import Document, Institution, Project
+
+
+class Command(BaseCommand):
+    help = "Validate stored URLs for Projects, Documents and Institutions."
+
+    def handle(self, *args, **options):
+        failures = []
+        total_checked = 0
+
+        for project in Project.objects.all():
+            total_checked += self._check_record(project, "Project", failures)
+
+        for institution in Institution.objects.all():
+            total_checked += self._check_record(institution, "Institution", failures)
+
+        for document in Document.objects.all():
+            total_checked += self._check_record(document, "Document", failures)
+
+        if failures:
+            for failure in failures:
+                print(failure)
+            print(f"Failures: {len(failures)} of {total_checked} URLs failed.")
+            sys.exit(1)
+
+        print(f"All URLs are reachable (checked {total_checked} URLs).")
+        sys.exit(0)
+
+    def _check_record(self, instance, model_name, failures):
+        url_value = getattr(instance, "url", "")
+        if not url_value:
+            return 0
+
+        success, reason = self._check_url(url_value)
+        if not success:
+            # Document uses 'title', others use 'name'
+            display_name = getattr(instance, "title", None) or getattr(instance, "name", "")
+            admin_url = self._build_admin_url(instance)
+            failures.append(
+                f'{model_name} id={instance.pk} name="{display_name}": {url_value} -> {reason} (admin: {admin_url})'
+            )
+        return 1
+
+    def _check_url(self, url):
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"}:
+            return False, "Invalid scheme"
+
+        head_ok, head_reason = self._request(url, method="HEAD")
+        if head_ok:
+            return True, ""
+
+        if head_reason in {"HTTP 400", "HTTP 403", "HTTP 405"}:
+            get_ok, get_reason = self._request(url, method="GET")
+            if get_ok:
+                return True, ""
+            return False, get_reason
+
+        return False, head_reason
+
+    def _request(self, url, method):
+        try:
+            context = ssl._create_unverified_context()
+            req = Request(url=url, method=method, headers={"User-Agent": "url-validator/1.0"})
+            with urlopen(req, timeout=15, context=context) as resp:
+                status = getattr(resp, "status", None) or resp.getcode()
+                if 200 <= status < 400:
+                    return True, ""
+                return False, f"HTTP {status}"
+        except HTTPError as exc:
+            return False, f"HTTP {exc.code}"
+        except URLError as exc:
+            return False, self._format_url_error(exc)
+        except Exception as exc:  # noqa: BLE001 - catch unexpected errors (timeout, etc.) to prevent command crash
+            return False, f"Error: {exc}"
+
+    def _format_url_error(self, exc):
+        reason = getattr(exc, "reason", None)
+        if reason:
+            return str(reason)
+        return str(exc)
+
+    def _build_admin_url(self, instance):
+        """Build the admin change URL for the instance.
+        If CSRF_TRUSTED_ORIGINS is configured, return full URL; otherwise return relative path."""
+        path = reverse(
+            f"admin:{instance._meta.app_label}_{instance._meta.model_name}_change",
+            args=[instance.pk],
+        )
+
+        if settings.CSRF_TRUSTED_ORIGINS:
+            base = settings.CSRF_TRUSTED_ORIGINS[0].rstrip("/") + "/"
+            return urljoin(base, path)
+
+        return path


### PR DESCRIPTION
Adds a management command to check URLs stored on Projects, Institutions, and Documents.

It runs through the existing records, checks whether the URLs are reachable, prints out any failures, and exits non-zero if something breaks. This is meant for once-off checks or cron usage and doesn’t affect the database.

Tested locally with working and broken URLs. When a URL fails, it prints the model, id/name, the URL, and the error. If any URL fails, the command exits with code 1; otherwise it exits with 0.