### PR TITLE
Add search form to institution detail page

### DIFF
--- a/app/general/tests/test_institution_detail.py
+++ b/app/general/tests/test_institution_detail.py
@@ -16,12 +16,22 @@ class InstitutionDetailViewTests(TestCase):
 
     def test_institution_detail_view_with_valid_id(self):
         with self.assertNumQueries(3):
-            response = self.client.get(reverse("institution_detail", args=[self.institution.id]))
+            response = self.client.get(reverse("institution_detail", args=[self.institution.pk]))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="main-heading"')
         self.assertContains(response, self.institution.name)
 
     def test_institution_detail_view_with_invalid_id(self):
-        invalid_id = self.institution.id + 1
+        invalid_id = self.institution.pk + 1
         response = self.client.get(reverse("institution_detail", args=[invalid_id]))
         self.assertEqual(response.status_code, 404)
+
+    def test_institution_detail_search_form(self):
+        response = self.client.get(reverse("institution_detail", args=[self.institution.pk]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, f'<input type="hidden" name="institution" value="{self.institution.pk}">'
+        )
+        self.assertContains(response, 'id="institution-search"')
+        self.assertContains(response, 'name="search"')
+        self.assertContains(response, 'type="submit"')

--- a/app/templates/app/institution_detail.html
+++ b/app/templates/app/institution_detail.html
@@ -32,6 +32,19 @@
         {% endif %}
     </div>
 
+    <section aria-label="{% trans 'Search form' %}" class="mb-4 limit-text-width">
+        <form method="get" action="{% url 'search' %}">
+            <input type="hidden" name="institution" value="{{ institution.pk }}">
+            <label for="institution-search" class="form-label">{% trans "Search through the resources below" %}</label>
+            <input type="search"
+                   id="institution-search"
+                   name="search"
+                   placeholder="{% trans 'Search term...' %}"
+                   class="form-control search-input">
+            <input type="submit" value="{% trans 'Search' %}" class="btn btn-primary mt-2">
+        </form>
+    </section>
+
     <div class="mb-3 row">
         {% if projects %}
         <div class="col-md-6">


### PR DESCRIPTION
- Added a search form to the institution detail page.
- The institution ID is prefilled, so the search is filtered for the selected institution.
- One-line layout: input + submit button inline, slightly different from the other search forms.
- Added tests to check that:
              1. Hidden institution input exists and has the correct value
              2. Search input field renders correctly
              3. Submit button renders correctly
- Ran Lighthouse in Chrome for accessibility, passed with a 100

Notes:
	• Button styling doesn’t exactly match other pages; I think this one-line approach works better, and we could standardize all search forms later (I can open an issue for that).
	• Spacing looks okay visually, but can tweak if needed.
	• search-input class matches the institution detail page; the search page uses slightly different styling.