### PR TITLE
Hide institution search form when no content exists

### DIFF
--- a/app/general/tests/test_institution_detail.py
+++ b/app/general/tests/test_institution_detail.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from general.models import Institution
+from general.models import Institution, Project
 
 
 class InstitutionDetailViewTests(TestCase):
@@ -27,7 +27,10 @@ class InstitutionDetailViewTests(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_institution_detail_search_form(self):
-        response = self.client.get(reverse("institution_detail", args=[self.institution.pk]))
+        Project.objects.create(name="Sample Project", institution=self.institution)
+
+        with self.assertNumQueries(3):
+            response = self.client.get(reverse("institution_detail", args=[self.institution.pk]))
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response, f'<input type="hidden" name="institution" value="{self.institution.pk}">'
@@ -35,3 +38,13 @@ class InstitutionDetailViewTests(TestCase):
         self.assertContains(response, 'id="institution-search"')
         self.assertContains(response, 'name="search"')
         self.assertContains(response, 'type="submit"')
+
+    def test_search_form_hidden_without_content(self):
+        with self.assertNumQueries(3):
+            response = self.client.get(reverse("institution_detail", args=[self.institution.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'id="institution-search"')
+        self.assertNotContains(
+            response, f'<input type="hidden" name="institution" value="{self.institution.pk}">'
+        )

--- a/app/templates/app/institution_detail.html
+++ b/app/templates/app/institution_detail.html
@@ -32,18 +32,20 @@
         {% endif %}
     </div>
 
-    <section aria-label="{% trans 'Search form' %}" class="mb-4 limit-text-width">
-        <form method="get" action="{% url 'search' %}">
-            <input type="hidden" name="institution" value="{{ institution.pk }}">
-            <label for="institution-search" class="form-label">{% trans "Search through the resources below" %}</label>
-            <input type="search"
-                   id="institution-search"
-                   name="search"
-                   placeholder="{% trans 'Search term...' %}"
-                   class="form-control search-input">
-            <input type="submit" value="{% trans 'Search' %}" class="btn btn-primary mt-2">
-        </form>
-    </section>
+    {% if projects or documents %}
+        <section aria-label="{% trans 'Search form' %}" class="mb-4 limit-text-width">
+            <form method="get" action="{% url 'search' %}">
+                <input type="hidden" name="institution" value="{{ institution.pk }}">
+                <label for="institution-search" class="form-label">{% trans "Search through the resources below" %}</label>
+                <input type="search"
+                    id="institution-search"
+                    name="search"
+                    placeholder="{% trans 'Search term...' %}"
+                    class="form-control search-input">
+                <input type="submit" value="{% trans 'Search' %}" class="btn btn-primary mt-2">
+            </form>
+        </section>
+    {% endif %}
 
     <div class="mb-3 row">
         {% if projects %}


### PR DESCRIPTION
Wrapped the institution detail search form in a content check so it only appears when the institution has searchable resources, meaning projects or documents.

Also updated the institution detail tests to cover both states: the form appears when content exists, and it stays hidden when there is no content.