### PR TITLE
Migrate to psycopg3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django==5.2.14
 gunicorn==25.3.0
 openpyxl==3.1.5
 pillow==12.2.0
-psycopg2-binary==2.9.12
+psycopg[binary]==3.3.4
 pypdf==6.10.2
 python-magic==0.4.27
 whitenoise[brotli]==6.12.0


### PR DESCRIPTION
Changed the PostgreSQL driver from psycopg2-binary to psycopg3 by replacing it with psycopg[binary] in requirements.txt.

I checked the current Django/PostgreSQL setup first and no settings changes were needed.

Ran the usual checks locally and everything looks fine on my side.