### PR TITLE
Rename document title to name

### DIFF
--- a/app/app/views.py
+++ b/app/app/views.py
@@ -168,7 +168,7 @@ def institution_detail(request, institution_id):
     documents = (
         Document.objects.filter(institution=institution)
         .defer("description", "document_data", "search_vector")
-        .order_by("title")
+        .order_by("name")
     )
 
     context = {
@@ -189,7 +189,7 @@ def documents(request):
         Document.objects.select_related("institution")
         .defer("document_data", "search_vector")
         .prefetch_related("subjects", "languages")
-        .order_by("title")
+        .order_by("name")
     )
 
     url_params = {}
@@ -263,7 +263,7 @@ def languages(request):
         .prefetch_related(
             Prefetch(
                 "document_set",
-                queryset=Document.objects.only("id", "title", "languages").order_by("title"),
+                queryset=Document.objects.only("id", "name", "languages").order_by("name"),
             ),
             Prefetch(
                 "project_set",
@@ -300,7 +300,7 @@ def subjects(request):
         .prefetch_related(
             Prefetch(
                 "document_set",
-                queryset=Document.objects.only("id", "title", "subjects").order_by("title"),
+                queryset=Document.objects.only("id", "name", "subjects").order_by("name"),
             ),
             Prefetch(
                 "project_set",

--- a/app/general/admin.py
+++ b/app/general/admin.py
@@ -87,12 +87,12 @@ class DocumentFormWithFulltext(DocumentForm):
 
 
 class DocumentAdmin(SimpleHistoryAdmin):
-    ordering = ["title"]
-    list_display = ["title", "license", "document_type", "verified", "standardised", "available"]
-    search_fields = ["title"]
+    ordering = ["name"]
+    list_display = ["name", "license", "document_type", "verified", "standardised", "available"]
+    search_fields = ["name"]
     list_filter = ["institution", "license", "document_type", "verified", "standardised"]
     form = DocumentForm
-    history_list_display = ["title", "license", "document_type", "available"]
+    history_list_display = ["name", "license", "document_type", "available"]
 
     def get_form(self, request, *args, **kwargs):
         # Show the fulltext field if the user has the requisite permission

--- a/app/general/filters.py
+++ b/app/general/filters.py
@@ -114,7 +114,7 @@ class DocumentFilter(django_filters.FilterSet):
             Left("document_data", 20_000), query, max_words=15, min_words=10
         )
         queryset = queryset.annotate(
-            heading=F("title"),
+            heading=F("name"),
             extra=F("description"),
             view=Value("document_detail"),
             logo_url=Value(""),

--- a/app/general/management/commands/dev_update_vector_search.py
+++ b/app/general/management/commands/dev_update_vector_search.py
@@ -9,4 +9,4 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         for document_file in Document.objects.all():
             document_file.save()  # This line updates the vector search for the document file
-            print(f"Updated {document_file.title}.")
+            print(f"Updated {document_file.name}.")

--- a/app/general/management/commands/import_documents.py
+++ b/app/general/management/commands/import_documents.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
 
         try:
             instance = Document(
-                title=file_name,
+                name=file_name,
                 document_data=pdf_to_text(file_path),
                 uploaded_file=content_file,
                 document_type="Glossary",

--- a/app/general/management/commands/validate_urls.py
+++ b/app/general/management/commands/validate_urls.py
@@ -43,8 +43,7 @@ class Command(BaseCommand):
 
         success, reason = self._check_url(url_value)
         if not success:
-            # Document uses 'title', others use 'name'
-            display_name = getattr(instance, "title", None) or getattr(instance, "name", "")
+            display_name = instance.name
             admin_url = self._build_admin_url(instance)
             failures.append(
                 f'{model_name} id={instance.pk} name="{display_name}": {url_value} -> {reason} (admin: {admin_url})'

--- a/app/general/migrations/0019_rename_document_title_to_name.py
+++ b/app/general/migrations/0019_rename_document_title_to_name.py
@@ -1,0 +1,70 @@
+import django.contrib.postgres.search
+import django.contrib.postgres.indexes
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("general", "0018_alter_document_uploaded_file_and_more"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="document",
+            old_name="title",
+            new_name="name",
+        ),
+        migrations.RenameField(
+            model_name="historicaldocument",
+            old_name="title",
+            new_name="name",
+        ),
+        migrations.AlterField(
+            model_name="document",
+            name="name",
+            field=models.CharField(max_length=200, verbose_name="name"),
+        ),
+        migrations.AlterField(
+            model_name="historicaldocument",
+            name="name",
+            field=models.CharField(max_length=200, verbose_name="name"),
+        ),
+        migrations.RemoveField(
+            model_name="document",
+            name="search_vector",
+        ),
+        migrations.AddField(
+            model_name="document",
+            name="search_vector",
+            field=models.GeneratedField(
+                blank=True,
+                db_persist=True,
+                expression=django.contrib.postgres.search.CombinedSearchVector(
+                    django.contrib.postgres.search.CombinedSearchVector(
+                        django.contrib.postgres.search.SearchVector(
+                            "name", config="english", weight="A"
+                        ),
+                        "||",
+                        django.contrib.postgres.search.SearchVector(
+                            "description", config="english", weight="B"
+                        ),
+                        django.contrib.postgres.search.SearchConfig("english"),
+                    ),
+                    "||",
+                    django.contrib.postgres.search.SearchVector(
+                        "document_data", config="english", weight="C"
+                    ),
+                    django.contrib.postgres.search.SearchConfig("english"),
+                ),
+                null=True,
+                output_field=django.contrib.postgres.search.SearchVectorField(),
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="document",
+            index=django.contrib.postgres.indexes.GinIndex(
+                fields=["search_vector"], name="general_doc_search__12340c_gin"
+            ),
+        ),
+    ]

--- a/app/general/models.py
+++ b/app/general/models.py
@@ -119,7 +119,7 @@ class Document(models.Model):
         ("Term list", _("Term list")),
     ]
 
-    title = models.CharField(max_length=200, verbose_name=_("title"))
+    name = models.CharField(max_length=200, verbose_name=_("name"))
     description = models.TextField(blank=True, verbose_name=_("description"))
     url = models.URLField(max_length=200, blank=True, verbose_name=_("URL"))
     uploaded_file = models.FileField(
@@ -167,7 +167,7 @@ class Document(models.Model):
     # immutable, otherwise the migration to the GeneratedField fails.
     search_vector = models.GeneratedField(
         expression=(
-            SearchVector("title", config="english", weight="A")
+            SearchVector("name", config="english", weight="A")
             + SearchVector("description", config="english", weight="B")
             + SearchVector("document_data", config="english", weight="C")
         ),
@@ -191,4 +191,4 @@ class Document(models.Model):
         permissions = [("can_edit_fulltext", "Can edit document fulltext (used for search)")]
 
     def __str__(self):
-        return self.title
+        return self.name

--- a/app/general/tests/test_document.py
+++ b/app/general/tests/test_document.py
@@ -12,7 +12,7 @@ class DocumentTest(TestCase):
         self.language = Language.objects.create(name="Test Language", iso_code="TL")
         self.institution = Institution.objects.create(name="Test Institution")
 
-        self.title = "Some document"
+        self.name = "Some document"
         self.url = "https://example.com"
         self.uploaded_file = SimpleUploadedFile(
             "example.pdf", b"file_content", content_type="application/pdf"
@@ -23,7 +23,7 @@ class DocumentTest(TestCase):
         self.institution = self.institution
 
         self.document = Document.objects.create(
-            title=self.title,
+            name=self.name,
             url=self.url,
             uploaded_file=self.uploaded_file,
             license=self.license,
@@ -36,17 +36,17 @@ class DocumentTest(TestCase):
 
     def test_document_creation(self):
         self.assertEqual(Document.objects.count(), 1)
-        self.assertEqual(Document.objects.get().title, self.title)
+        self.assertEqual(Document.objects.get().name, self.name)
 
     def test_document_str_representation(self):  # Test __str__ method
-        self.assertEqual(str(self.document), self.title)
+        self.assertEqual(str(self.document), self.name)
 
     def test_document_available_by_default(self):  # Test default value
         self.assertTrue(self.document.available)
 
     def test_history_records_creation(self):
         self.assertEqual(self.document.history.count(), 1)
-        self.assertEqual(self.document.history.first().title, "Some document")
+        self.assertEqual(self.document.history.first().name, "Some document")
         self.assertEqual(self.document.history.first().url, "https://example.com")
         self.assertEqual(self.document.history.first().uploaded_file, "documents/example.pdf")
         self.assertEqual(self.document.history.first().license, "MIT")

--- a/app/general/tests/test_document_admin.py
+++ b/app/general/tests/test_document_admin.py
@@ -38,7 +38,7 @@ class TestDocumentForm(TestCase):
 
     def test_clean_without_url_and_file(self):
         tests_form = {
-            "title": "Test",
+            "name": "Test",
             "license": "MIT",
             "document_type": "Glossary",
             "mime_type": "pdf",
@@ -57,7 +57,7 @@ class TestDocumentForm(TestCase):
 
     def test_clean_without_file(self):
         tests_form = {
-            "title": "Test",
+            "name": "Test",
             "license": "(c)",
             "document_type": "Glossary",
             "mime_type": "pdf",
@@ -74,7 +74,7 @@ class TestDocumentForm(TestCase):
     #
     def test_clean_without_url(self):
         tests_form = {
-            "title": "Test",
+            "name": "Test",
             "license": "CC0",
             "document_type": "Glossary",
             "mime_type": "pdf",
@@ -90,7 +90,7 @@ class TestDocumentForm(TestCase):
 
     def test_clean_with_xlsx_file(self):
         tests_form = {
-            "title": "Test",
+            "name": "Test",
             "license": "CC0",
             "document_type": "Glossary",
             "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -112,7 +112,7 @@ class TestDocumentForm(TestCase):
         self.pdf_file.size = 15728640
 
         tests_form = {
-            "title": "Test",
+            "name": "Test",
             "license": "MIT",
             "document_type": "Glossary",
             "mime_type": "pdf",
@@ -129,7 +129,7 @@ class TestDocumentForm(TestCase):
 
     def test_edited_pdf_takes_priority_over_unedited_fulltext(self):
         tests_form = {
-            "title": "Test",
+            "name": "Test",
             "license": "CC0",
             "document_type": "Glossary",
             "mime_type": "pdf",
@@ -149,7 +149,7 @@ class TestDocumentForm(TestCase):
     def test_edited_fulltext_takes_priority_over_edited_pdf(self):
         custom_data = "testingstringthatisnotinsidelorem.pdf"
         tests_form = {
-            "title": "Test",
+            "name": "Test",
             "license": "CC0",
             "document_type": "Glossary",
             "mime_type": "pdf",
@@ -166,11 +166,11 @@ class TestDocumentForm(TestCase):
         self.assertEqual(form.cleaned_data["document_data"], custom_data)
 
     def test_edited_fulltext_reflects_in_database_and_search(self):
-        title = "Test document with edited fulltext"
+        name = "Test document with edited fulltext"
         custom_data = "testingstringthatisnotinsidelorem.pdf"
 
         original_form = {
-            "title": title,
+            "name": name,
             "license": "CC0",
             "document_type": "Glossary",
             "mime_type": "pdf",
@@ -191,7 +191,7 @@ class TestDocumentForm(TestCase):
         # Check we can search by PDF content
         response = self.client.get(reverse("search"), {"search": orig_fulltext})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["page_obj"][0]["heading"], title)
+        self.assertEqual(response.context["page_obj"][0]["heading"], name)
 
         # Now, upload a copy with edited fulltext
         edit_form = {**original_form, "document_data": custom_data, "id": doc.id}
@@ -202,13 +202,13 @@ class TestDocumentForm(TestCase):
         doc = form.save()
         self.assertEqual(doc.document_data, custom_data)
 
-        # Check that: 1. we only have one document with this title, and 2. it has the correct fulltext
-        self.assertEqual(Document.objects.get(title=title).document_data, custom_data)
+        # Check that: 1. we only have one document with this name, and 2. it has the correct fulltext
+        self.assertEqual(Document.objects.get(name=name).document_data, custom_data)
 
         # Check we can search by the new content too
         response = self.client.get(reverse("search"), {"search": custom_data})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["page_obj"][0]["heading"], title)
+        self.assertEqual(response.context["page_obj"][0]["heading"], name)
 
         # Check that we CANNOT search by the old content anymore
         response = self.client.get(reverse("search"), {"search": orig_fulltext})

--- a/app/general/tests/test_document_detail.py
+++ b/app/general/tests/test_document_detail.py
@@ -15,7 +15,7 @@ class DocumentDetailViewTest(TestCase):
         self.language2 = Language.objects.create(name="English", iso_code="en")
 
         self.document = Document.objects.create(
-            title="Afrikaans_HL_P1_Feb-March_2011",
+            name="Afrikaans_HL_P1_Feb-March_2011",
             description="This is a description of the document.",
             url="https://externaldocumentrepository.com/document1",
             uploaded_file="path/to/document.pdf",
@@ -36,7 +36,7 @@ class DocumentDetailViewTest(TestCase):
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="main-heading"')
-        self.assertContains(response, self.document.title)
+        self.assertContains(response, self.document.name)
         self.assertContains(response, self.institution.name)
         self.assertContains(response, self.subject1.name)
         self.assertContains(response, self.language1.name)

--- a/app/general/tests/test_documents.py
+++ b/app/general/tests/test_documents.py
@@ -17,14 +17,14 @@ class DocumentViewTests(TestCase):
         )
 
         self.document5 = Document.objects.create(
-            title="Document 5",
+            name="Document 5",
             institution=self.institution,
         )
         self.document5.subjects.add(self.subject1)
         self.document5.languages.add(self.language1)
 
         self.document6 = Document.objects.create(
-            title="Document 6",
+            name="Document 6",
             institution=self.institution,
         )
         self.document6.subjects.add(self.subject1)
@@ -47,4 +47,4 @@ class DocumentViewTests(TestCase):
         response = self.client.get(reverse("documents"), {"language": self.language3.id})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["documents"]), 1)
-        self.assertEqual(response.context["documents"][0]["document"].title, "Document 6")
+        self.assertEqual(response.context["documents"][0]["document"].name, "Document 6")

--- a/app/general/tests/test_filter.py
+++ b/app/general/tests/test_filter.py
@@ -21,7 +21,7 @@ class TestSearchFilter(TestCase):
 
         # Create Documents
         self.doc1 = Document.objects.create(
-            title="Document 1",
+            name="Document 1",
             document_data="Document 1 content",
             institution=self.institution1,
             document_type="glossary",
@@ -30,7 +30,7 @@ class TestSearchFilter(TestCase):
         self.doc1.languages.add(self.language1)
 
         self.doc2 = Document.objects.create(
-            title="Document 2",
+            name="Document 2",
             document_data="Document 2 content",
             institution=self.institution2,
             document_type="glossary",

--- a/app/general/tests/test_import_documents.py
+++ b/app/general/tests/test_import_documents.py
@@ -20,7 +20,7 @@ class TestHandleFile(unittest.TestCase):
 
     def tearDown(self):
         try:
-            document_file = Document.objects.get(title=self.name)
+            document_file = Document.objects.get(name=self.name)
             path = document_file.uploaded_file.path
             if os.path.isfile(path):
                 os.remove(path)
@@ -52,6 +52,6 @@ class TestHandleFile(unittest.TestCase):
             )
 
         command.save_data(self.test_file, self.name)
-        document_file = Document.objects.get(title=self.name)
-        self.assertEqual(document_file.title, self.name)
+        document_file = Document.objects.get(name=self.name)
+        self.assertEqual(document_file.name, self.name)
         self.assertIn("Lorem ipsum dolor", document_file.document_data)

--- a/app/general/tests/test_languages.py
+++ b/app/general/tests/test_languages.py
@@ -17,12 +17,12 @@ class LanguagesViewTest(TestCase):
         self.language2 = Language.objects.create(name="Spanish", iso_code="lang2")
 
         self.document1 = Document.objects.create(
-            title="Document 1", institution=self.institution, document_type="report"
+            name="Document 1", institution=self.institution, document_type="report"
         )
         self.document1.languages.add(self.language1)
 
         self.document2 = Document.objects.create(
-            title="Document 2", institution=self.institution, document_type="report"
+            name="Document 2", institution=self.institution, document_type="report"
         )
         self.document2.languages.add(self.language2)
 

--- a/app/general/tests/test_view_search.py
+++ b/app/general/tests/test_view_search.py
@@ -24,7 +24,7 @@ class SearchViewTest(TestCase):
         # Create documents
         for i in range(10):
             doc = Document.objects.create(
-                title=f"Document {i + 1}",
+                name=f"Document {i + 1}",
                 institution=self.institution1 if i % 2 == 0 else self.institution2,
                 document_type="report" if i % 2 == 0 else "article",
                 document_data="Document {i + 1} content",

--- a/app/general/tests/test_views_institution.py
+++ b/app/general/tests/test_views_institution.py
@@ -19,8 +19,8 @@ class InstitutionsViewTestCase(TestCase):
 
         Project.objects.create(name="Test Project 1", institution=inst1)
         Project.objects.create(name="Test Project 2", institution=inst1)
-        Document.objects.create(title="Test document 1", institution=inst1)
-        Document.objects.create(title="Test document 2", institution=inst1)
+        Document.objects.create(name="Test document 1", institution=inst1)
+        Document.objects.create(name="Test document 2", institution=inst1)
 
         self.url = reverse("institutions")
 

--- a/app/general/tests/tests_subject.py
+++ b/app/general/tests/tests_subject.py
@@ -17,12 +17,12 @@ class TestSubjects(TestCase):
         self.subject2 = Subject.objects.create(name="Science")
 
         self.document1 = Document.objects.create(
-            title="Document 1", institution=self.institution, document_type="report"
+            name="Document 1", institution=self.institution, document_type="report"
         )
         self.document1.subjects.add(self.subject1)
 
         self.document2 = Document.objects.create(
-            title="Document 2", institution=self.institution, document_type="report"
+            name="Document 2", institution=self.institution, document_type="report"
         )
         self.document2.subjects.add(self.subject2)
 

--- a/app/templates/app/_documents.html
+++ b/app/templates/app/_documents.html
@@ -12,7 +12,7 @@
                 {% for document in item.documents %}
                 <li class="mb-2">
                     {% icon "document" %}
-                    <a href="{% url 'document_detail' document.id %}">{{ document.title }}</a>
+                    <a href="{% url 'document_detail' document.pk %}">{{ document.name }}</a>
                 </li>
                 {% endfor %}
             </ul>

--- a/app/templates/app/document_detail.html
+++ b/app/templates/app/document_detail.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load bs_icons %}
 
-{% block title %}{{ document.title }}{% endblock %}
+{% block title %}{{ document.name }}{% endblock %}
 
 {% block content %}
 {% spaceless %}
@@ -10,12 +10,12 @@
     <nav aria-label="{% trans 'Breadcrumb' %}">
         <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="{% url 'documents' %}">{% trans "Documents" %}</a></li>
-            <li class="breadcrumb-item active" aria-current="page">{{ document.title }}</li>
+            <li class="breadcrumb-item active" aria-current="page">{{ document.name }}</li>
         </ol>
     </nav>
 
     <div>
-        <h1 id="main-heading">{{ document.title }}</h1>
+        <h1 id="main-heading">{{ document.name }}</h1>
         {% if document.url %}
         <div class="mb-2">
             <a href="{{ document.url }}" target="_blank"

--- a/app/templates/app/documents.html
+++ b/app/templates/app/documents.html
@@ -14,8 +14,8 @@
     {% for item in documents %}
         <div class="mt-4">{# additional indent simplifies comparison with projects.html #}
             <h2>
-                <a href="{% url 'document_detail' item.document.id %}" class="text-decoration-none">
-                    {{ item.document.title }}
+                <a href="{% url 'document_detail' item.document.pk %}" class="text-decoration-none">
+                    {{ item.document.name }}
                 </a>
             </h2>
             {% if item.document.url %}
@@ -31,7 +31,7 @@
             </div>
             <p class="limit-text-width">
                 {{ item.document.description|truncatewords:30 }}
-                <a href="{% url 'document_detail' item.document.id %}">{% trans "More about the document" %}</a>
+                <a href="{% url 'document_detail' item.document.pk %}">{% trans "More about the document" %}</a>
             </p>
 
             {% if item.languages %}

--- a/app/templates/app/institution_detail.html
+++ b/app/templates/app/institution_detail.html
@@ -68,7 +68,7 @@
                 {% for document in documents %}
                     <li class="m-2">
                         {% icon "document" %}
-                        <a href="{% url 'document_detail' document.id %}">{{ document.title }}</a>
+                        <a href="{% url 'document_detail' document.pk %}">{{ document.name }}</a>
                     </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
This renames `Document.title` to `Document.name` so it lines up with `Project` and `Institution`.

I updated the places that still used `title`, including the admin, views, templates, filters, management commands and related tests. The migration uses `RenameField`, so the existing values are preserved.

I also removed the small workaround in `validate_urls` where `Document` had to be handled differently from the other models.

I tested the migration, checks, targeted backend tests, URL validation and formatting, and everything checked out with no new errors.

Closes #202