### PR TITLE
Improve institution search navigation

### DIFF
--- a/app/app/views.py
+++ b/app/app/views.py
@@ -403,9 +403,23 @@ def search(request):
         "filter": f,
         "page_obj": page_obj,
         "url_params": pagination_url(request),
+        "single_institution": get_single_institution(f.form),
     }
 
     return render(request, template_name=template, context=context)
+
+
+def get_single_institution(form):
+    institutions = form.cleaned_data.get("institution")
+    subjects = form.cleaned_data.get("subjects")
+    languages = form.cleaned_data.get("languages")
+
+    # Only show the nav link when institution is the sole active filter. Showing
+    # it with other filters could imply the results belong only to that institution.
+    if institutions and len(institutions) == 1 and not subjects and not languages:
+        return institutions[0]
+
+    return None
 
 
 def pagination_url(request):

--- a/app/general/tests/test_view_search.py
+++ b/app/general/tests/test_view_search.py
@@ -9,8 +9,8 @@ from general.models import Document, Institution, Language, Subject
 class SearchViewTest(TestCase):
     def setUp(self):
         # Create institutions
-        self.institution1 = Institution.objects.create(name="Institution 1")
-        self.institution2 = Institution.objects.create(name="Institution 2")
+        self.institution1 = Institution.objects.create(name="Institution 1", abbreviation="I1")
+        self.institution2 = Institution.objects.create(name="Institution 2", abbreviation="I2")
 
         # Create languages
         self.language1 = Language.objects.create(name="English", iso_code="EN")
@@ -56,6 +56,33 @@ class SearchViewTest(TestCase):
         response = self.client.get(reverse("search"), {"search": "Document 1"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["page_obj"][0]["heading"], "Document 1")
+
+    def test_institution_filter_shows_nav_link(self):
+        response = self.client.get(reverse("search"), {"institution": self.institution1.pk})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            f"""
+            <a href="{reverse("institution_detail", args=[self.institution1.pk])}"
+               hx-target="#main" hx-select="#main"
+               class="btn btn-secondary">
+                Go to {self.institution1.abbreviation}
+            </a>
+            """,
+            html=True,
+        )
+        self.assertNotContains(
+            response, f'href="{reverse("search")}?institution={self.institution1.pk}"'
+        )
+
+    def test_search_with_many_filters_hides_nav_link(self):
+        response = self.client.get(
+            reverse("search"),
+            {"institution": self.institution1.pk, "subjects": self.subject1.pk},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, f"Go to {self.institution1.abbreviation}")
 
     def test_invalid_page_number(self):
         response = self.client.get(reverse("search"), {"page": "invalid"})

--- a/app/templates/app/institution_detail.html
+++ b/app/templates/app/institution_detail.html
@@ -18,7 +18,8 @@
         <div class="{% if institution.logo %}col-md-6{% else %}col-md-12{% endif %}">
             <h1 id="main-heading">{{ institution.name }} ({{ institution.abbreviation }})</h1>
             {% if institution.url %}
-                <p><a href="{{ institution.url }}">{{ institution.url }}</a></p>
+                <p><a href="{{ institution.url }}" target="_blank" rel="noopener noreferrer"
+                      title="{% trans 'External link' %}">{{ institution.url }}</a></p>
             {% endif %}
             {% if institution.email %}
                 <p><a href="mailto:{{ institution.email }}">{{ institution.email }}</a></p>

--- a/app/templates/app/search.html
+++ b/app/templates/app/search.html
@@ -30,9 +30,20 @@ structure.
                            class="form-control"
                            value="{{ request.GET.search }}">
                 </div>
-                <div class="col-auto">
-                    <input type="submit" class="btn btn-primary me-4">
+                <div class="col-auto d-flex flex-wrap align-items-center gap-2">
+                    <input type="submit" class="btn btn-primary">
                     <a href="{% url 'search' %}" hx-target="#main" hx-select="#main" class="btn btn-secondary">{% trans 'Reset' %}</a>
+                    {% if single_institution %}
+                    <a href="{% url 'institution_detail' single_institution.pk %}"
+                       hx-target="#main" hx-select="#main"
+                       class="btn btn-secondary">
+                        {% if single_institution.abbreviation %}
+                            {% blocktrans with institution_name=single_institution.abbreviation %}Go to {{ institution_name }}{% endblocktrans %}
+                        {% else %}
+                            {% trans "Go to institution" %}
+                        {% endif %}
+                    </a>
+                    {% endif %}
                 </div>
                 {% if page_obj.paginator.num_pages > 1 %}
                 <div class="mt-2">


### PR DESCRIPTION
Adds a small nav link on the search results page when the search is filtered to a single institution.

The link says `Go to <Institution>` and takes the user to that institution page. I used `Go to` rather than `Back to` so the wording still works if we later extend this to other single filters, like language or subject.

The link only shows when there is exactly one institution filter active. If there are extra filters, it stays hidden so the page does not imply that the results only belong to one institution.

I also changed the external institution website link to open in a new tab, since that takes the user away from LwimiLinks.

Tested the search view changes and the relevant checks passed with no new errors.