### PR TITLE
Autoremove orphaned Debian packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN <<EOF
   apt-get install -y --no-install-recommends libmagic1 gettext build-essential libmagic-dev
   pip install --upgrade pip
   pip install -r requirements.txt
-  apt-get remove -y build-essential libmagic-dev
+  apt-get remove --autoremove -y build-essential libmagic-dev
   rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -22,7 +22,7 @@ RUN <<EOF
   npm install -g @lhci/cli@0.14.x
   pip install --upgrade pip
   pip install -r requirements-dev.txt
-  apt-get remove -y build-essential libmagic-dev
+  apt-get remove --autoremove -y build-essential libmagic-dev
   rm -rf /var/lib/apt/lists/*
 EOF
 


### PR DESCRIPTION
Due to gcc being pulled in through build-essential, this should save at least tens of megabytes.