### PR TITLE
Compile translations during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN <<EOF
   set -exo pipefail
   apt-get update
   apt-get -y upgrade
-  apt-get install -y --no-install-recommends libmagic1 gettext build-essential libmagic-dev
+  apt-get install -y --no-install-recommends libmagic1 build-essential libmagic-dev
   pip install --upgrade pip
   pip install -r requirements.txt
   apt-get remove --autoremove -y build-essential libmagic-dev
@@ -27,6 +27,17 @@ EOF
 # Copy project
 COPY ./entrypoint.sh /
 COPY ./app /app/
+
+# Compile translations at build time without keeping gettext in the runtime image.
+RUN <<EOF
+  set -exo pipefail
+  apt-get update
+  apt-get install -y --no-install-recommends gettext
+  mkdir -p /logging
+  SECRET_KEY=build-only-secret-key python manage.py compilemessages
+  apt-get purge --autoremove -y gettext
+  rm -rf /var/lib/apt/lists/*
+EOF
 
 # Run the application
 ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,5 @@ set -x
 python manage.py check --deploy --database default
 python manage.py migrate --no-input
 python manage.py collectstatic --no-input
-python manage.py compilemessages
 
 gunicorn app.wsgi:application --bind 0.0.0.0:8000 --config gunicorn.conf.py


### PR DESCRIPTION
Moved `compilemessages` out of `entrypoint.sh` and into the Docker build, so we don't need gettext in the running production image anymore.

Tested by building the production image, checking that the `django.mo` files are generated for `af` and `en`, and confirming that gettext/msgfmt are not installed in the final image. All of these checks passed.