### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/analyze_ga.yml
+++ b/.github/workflows/analyze_ga.yml
@@ -1,0 +1,28 @@
+name: Analyse Github Actions
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  analyse-github-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0
+        with:
+          python-version: 3.12
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install zizmor
+      - name: Run zizmor
+        run: |
+          zizmor .github/workflows/*.yml

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -7,26 +7,27 @@ on:
     branches:
       - "main"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   deploy_test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to SADiLaR Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: docker.sadilar.org
           username: ${{ vars.SADILAR_DOCKER_REPOSITORY_USER }}
           password: ${{ secrets.SADILAR_DOCKER_REPOSITORY_SECRET }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           platforms: linux/amd64
@@ -34,7 +35,7 @@ jobs:
           tags: |
             docker.sadilar.org/term_platform:latest
       - name: Use webhook action to start deployment     
-        uses: joelwmale/webhook-action@2.3.2
+        uses: joelwmale/webhook-action@448a17bf857ead98546cfbdbe3b9d4cf979dda95 # 2.3.2
         with:
           url: https://api.bitbucket.org/2.0/repositories/team_sadilar/ansible/pipelines/
           headers: '{"Authorization": "Bearer ${{ secrets.BITBUCKET_PIPELINE_SECRET }}"}'

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -6,26 +6,27 @@ on:
     tags:
       - v**
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   docker_push:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to SADiLaR Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: docker.sadilar.org
           username: ${{ vars.SADILAR_DOCKER_REPOSITORY_USER }}
           password: ${{ secrets.SADILAR_DOCKER_REPOSITORY_SECRET }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,8 @@ on:
       - develop
   pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   test_project:
@@ -24,10 +25,10 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.12
       - name: Install Dependencies
@@ -89,10 +90,10 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.12
       - name: Install Dependencies
@@ -113,7 +114,7 @@ jobs:
           BROWSER=${{ matrix.browser-and-os[0] }} JS_ENABLED=${{ matrix.js }} python manage.py test --tag=selenium
       - name: Archive Selenium screenshots
         if: always() # Ensure results are uploaded on failure too
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: selenium-screenshots
           path: app/selenium-screenshots/
@@ -130,13 +131,13 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.12
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
       - name: Install Dependencies
@@ -160,14 +161,14 @@ jobs:
         run: cd app && lhci autorun
       - name: Archive Lighthouse results
         if: always() # Ensure results are uploaded on failure too
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: lighthouse-report
           path: app/.lighthouseci/
           include-hidden-files: true
       - name: Archive Django logs
         if: always() # Ensure logs are uploaded on failure too
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: django-logs
           path: app/debug.log
@@ -176,7 +177,7 @@ jobs:
     if: github.event.ref != 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
Added a GitHub Actions workflow to run zizmor on our workflows.

While setting that up, I also fixed the issues it was reporting by pinning action versions to commit SHAs and tightening workflow permissions where possible.

Ran zizmor afterwards and everything passed.